### PR TITLE
Add NBA betting predictor example

### DIFF
--- a/nba_betting_app/README.md
+++ b/nba_betting_app/README.md
@@ -1,0 +1,30 @@
+# NBA Betting Predictor
+
+This simple command line app loads past NBA game results from a CSV file and
+computes a basic rating for each team based on average point differential.
+Predictions for upcoming games are generated using these ratings and a logistic
+function to produce a win probability for the home team.
+
+## Data
+
+Sample data is provided in `data/sample_games.csv`. The CSV should contain the
+following columns:
+
+```
+date,home_team,away_team,home_points,away_points
+```
+
+Additional games can be added to improve the model.
+
+## Usage
+
+```
+python predictor.py --data data/sample_games.csv "Lakers" "Bulls"
+```
+
+This will output the predicted probability that the home team (first argument)
+beats the away team (second argument) based on the historical data.
+
+The model is intentionally simple and meant only as an example. For real sports
+betting use, more sophisticated statistics and much larger datasets would be
+required.

--- a/nba_betting_app/data/sample_games.csv
+++ b/nba_betting_app/data/sample_games.csv
@@ -1,0 +1,11 @@
+date,home_team,away_team,home_points,away_points
+2022-10-01,Lakers,Bulls,110,100
+2022-10-02,Celtics,Heat,95,102
+2022-10-03,Bulls,Celtics,98,97
+2022-10-04,Heat,Lakers,105,99
+2022-10-05,Lakers,Celtics,112,108
+2022-10-06,Bulls,Heat,90,88
+2022-10-07,Celtics,Lakers,101,107
+2022-10-08,Heat,Bulls,100,95
+2022-10-09,Lakers,Heat,115,113
+2022-10-10,Bulls,Lakers,94,101

--- a/nba_betting_app/predictor.py
+++ b/nba_betting_app/predictor.py
@@ -1,0 +1,63 @@
+import csv
+import math
+import argparse
+from collections import defaultdict
+
+
+def load_games(path):
+    """Load games from a CSV file."""
+    games = []
+    with open(path, newline='') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            game = {
+                'home_team': row['home_team'],
+                'away_team': row['away_team'],
+                'home_points': int(row['home_points']),
+                'away_points': int(row['away_points'])
+            }
+            games.append(game)
+    return games
+
+
+def compute_team_ratings(games):
+    """Compute average point differential for each team."""
+    totals = defaultdict(lambda: {'diff_sum': 0, 'games': 0})
+    for g in games:
+        diff = g['home_points'] - g['away_points']
+        totals[g['home_team']]['diff_sum'] += diff
+        totals[g['home_team']]['games'] += 1
+        totals[g['away_team']]['diff_sum'] -= diff
+        totals[g['away_team']]['games'] += 1
+    ratings = {}
+    for team, vals in totals.items():
+        ratings[team] = vals['diff_sum'] / vals['games']
+    return ratings
+
+
+def predict(home_team, away_team, ratings, k=0.1):
+    """Predict home team win probability using logistic on rating diff."""
+    rating_home = ratings.get(home_team, 0)
+    rating_away = ratings.get(away_team, 0)
+    diff = rating_home - rating_away
+    prob_home_win = 1 / (1 + math.exp(-k * diff))
+    return prob_home_win
+
+
+def main():
+    parser = argparse.ArgumentParser(description="NBA Betting Predictor")
+    parser.add_argument('--data', default='nba_betting_app/data/sample_games.csv',
+                        help='Path to games CSV data')
+    parser.add_argument('home_team', help='Home team name')
+    parser.add_argument('away_team', help='Away team name')
+    args = parser.parse_args()
+
+    games = load_games(args.data)
+    ratings = compute_team_ratings(games)
+    prob = predict(args.home_team, args.away_team, ratings)
+
+    print(f"Predicted probability {args.home_team} beats {args.away_team}: {prob:.3f}")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- create a small nba_betting_app directory
- add simple predictor script and sample dataset
- document usage in README

## Testing
- `python3 nba_betting_app/predictor.py Lakers Bulls`

------
https://chatgpt.com/codex/tasks/task_e_68463d91c5e0832ca34a40caaa6d33e7